### PR TITLE
Fix desyncs + reload-reconnect + disconnect indicator

### DIFF
--- a/src/components/field/Field.js
+++ b/src/components/field/Field.js
@@ -81,6 +81,8 @@ import {
   setEnemyCardSelectedInHand,
   setCardSelectedOnField,
   setEnemyCardSelectedOnField,
+  setRoom,
+  setSelfOnlineStatus,
 } from "../../redux/CardSlice";
 import { cardImage } from "../../decks/getCards";
 import { motion } from "framer-motion";
@@ -98,7 +100,7 @@ import EnemyEvoDeck from "./EnemyEvoDeck";
 import img from "../../assets/pin_bellringer_angel.png";
 import "../../css/AnimatedBorder.css";
 import { useNavigate } from "react-router-dom";
-import { socket, playerId } from "../../sockets";
+import { socket, playerId, getSavedRoom } from "../../sockets";
 import useSocketStateSync from "../hooks/useSocketStateSync";
 import useReceiveFullState from "../hooks/useReceiveFullState";
 import useStoreState from "../hooks/useStoreState";
@@ -235,10 +237,19 @@ export default function Field({
     };
   }, [reduxRoom]);
 
-  // Message queue to handle out-of-order messages
-  const messageQueueRef = useRef([]);
-  const lastSequenceRef = useRef(-1);
-  const processingRef = useRef(false);
+  // Per-sender sequence tracking for gap detection: { [senderId]: lastSeq }
+  const lastSeqBySenderRef = useRef({});
+  // Throttle full-state resync requests so a burst of gaps can't storm.
+  const lastResyncRef = useRef(0);
+
+  const requestResync = useCallback(() => {
+    if (!reduxRoom) return;
+    const now = Date.now();
+    if (now - lastResyncRef.current < 1500) return;
+    lastResyncRef.current = now;
+    console.log("[resync] requesting full state from opponent");
+    socket.emit("request_state", { room: reduxRoom });
+  }, [reduxRoom]);
 
   // Process a single update (batched with others)
   const handleUpdate = useCallback(
@@ -403,8 +414,6 @@ export default function Field({
               if (fullState.enemyLog !== undefined)
                 dispatch(setEnemyLog(fullState.enemyLog));
             });
-            // Reset sequence after full state sync
-            lastSequenceRef.current = -1;
           }
           break;
         default:
@@ -414,68 +423,75 @@ export default function Field({
     [dispatch],
   );
 
-  // Process queued messages in order
-  const processQueue = useCallback(() => {
-    if (processingRef.current) return;
-    processingRef.current = true;
-
-    // Sort queue by sequence number if available, otherwise by timestamp
-    messageQueueRef.current.sort((a, b) => {
-      if (a.sequence !== undefined && b.sequence !== undefined) {
-        return a.sequence - b.sequence;
-      }
-      return a.timestamp - b.timestamp;
-    });
-
-    // Process all ready messages
-    while (messageQueueRef.current.length > 0) {
-      const message = messageQueueRef.current[0];
-
-      // If sequence numbers are used, only process if it's the next expected one
-      if (message.sequence !== undefined) {
-        if (message.sequence !== lastSequenceRef.current + 1) {
-          // Wait for the correct sequence
-          break;
-        }
-        lastSequenceRef.current = message.sequence;
-      }
-
-      // Remove from queue
-      messageQueueRef.current.shift();
-
-      // Process all updates in this message atomically using batched updates
+  // Apply a single message (which may carry one update or a batch of updates).
+  // Every update carries the full new value of a field (last-write-wins), so
+  // applying the newest message is always safe — the only risk is a *missing*
+  // field update, which gap detection in handleMessage repairs via resync.
+  const applyMessage = useCallback(
+    (message) => {
       if (message.updates && Array.isArray(message.updates)) {
-        // Batch all dispatches together to prevent intermediate renders
         unstable_batchedUpdates(() => {
-          message.updates.forEach((update) => {
-            handleUpdate(update);
-          });
+          message.updates.forEach((update) => handleUpdate(update));
         });
       } else {
-        // Single update - still batch it
-        unstable_batchedUpdates(() => {
-          handleUpdate(message);
-        });
+        unstable_batchedUpdates(() => handleUpdate(message));
       }
-    }
-
-    processingRef.current = false;
-  }, [handleUpdate]);
+    },
+    [handleUpdate],
+  );
 
   useEffect(() => {
     const handleMessage = (data) => {
-      // Add sequence number and timestamp if not present
-      const message = {
-        ...data,
-        sequence: data.sequence,
-        timestamp: data.timestamp || Date.now(),
-      };
+      const sender = data._from;
+      const seq = data._seq;
 
-      // Add to queue
-      messageQueueRef.current.push(message);
+      // Legacy / untagged message (no sequence info) — just apply it.
+      if (sender === undefined || seq === undefined) {
+        applyMessage(data);
+        return;
+      }
 
-      // Process queue
-      processQueue();
+      const seen = lastSeqBySenderRef.current;
+      const last = seen[sender];
+
+      if (last === undefined) {
+        // First message from this opponent this session. If it doesn't start
+        // at 1, or another opponent id was already tracked (opponent
+        // reconnected with a new socket id), we may have missed earlier
+        // updates — pull a full state to be safe.
+        const sawOtherSender = Object.keys(seen).length > 0;
+        seen[sender] = seq;
+        applyMessage(data);
+        if (seq > 1 || sawOtherSender) requestResync();
+        return;
+      }
+
+      if (seq === last) {
+        // Exact duplicate (e.g. a replayed packet) — ignore.
+        return;
+      }
+
+      if (seq < last) {
+        // Sequence went backwards => the server/socket counter reset
+        // (server restart or socket reuse). Re-baseline and resync.
+        seen[sender] = seq;
+        applyMessage(data);
+        requestResync();
+        return;
+      }
+
+      if (seq > last + 1) {
+        // Gap: one or more updates were lost. Apply the newest value, then
+        // resync to repair any field whose only update fell in the gap.
+        seen[sender] = seq;
+        applyMessage(data);
+        requestResync();
+        return;
+      }
+
+      // In order (seq === last + 1).
+      seen[sender] = seq;
+      applyMessage(data);
     };
 
     socket.on("receive msg", handleMessage);
@@ -487,13 +503,36 @@ export default function Field({
       socket.off("online");
       socket.off("offline");
     };
-  }, [dispatch, processQueue]);
+  }, [dispatch, applyMessage, requestResync]);
 
   useEffect(() => {
     if (reduxCurrentRoom.length === 0) {
-      navigate("/");
+      // The `card` slice isn't persisted, so a hard reload lands here with an
+      // empty room. If we remembered a room (i.e. the player didn't explicitly
+      // leave), restore it and let the reconnect effect rejoin + pull state,
+      // instead of bouncing back to the home screen.
+      const saved = getSavedRoom();
+      if (saved) {
+        dispatch(setRoom(saved));
+      } else {
+        navigate("/");
+      }
     }
-  }, [reduxCurrentRoom, navigate]);
+  }, [reduxCurrentRoom, navigate, dispatch]);
+
+  // Track this client's own connection so the UI can show a disconnected
+  // indicator (the WifiOff icon) while we're offline / reconnecting.
+  useEffect(() => {
+    const onConnect = () => dispatch(setSelfOnlineStatus(true));
+    const onDisconnect = () => dispatch(setSelfOnlineStatus(false));
+    dispatch(setSelfOnlineStatus(socket.connected));
+    socket.on("connect", onConnect);
+    socket.on("disconnect", onDisconnect);
+    return () => {
+      socket.off("connect", onConnect);
+      socket.off("disconnect", onDisconnect);
+    };
+  }, [dispatch]);
 
   useEffect(() => {
     dispatch(setCardSelectedInHand(-1));

--- a/src/components/hooks/useReceiveFullState.js
+++ b/src/components/hooks/useReceiveFullState.js
@@ -69,36 +69,19 @@ const useReceiveFullState = () => {
       });
     });
 
-    // Fallback: peer-based sync (opponent sends their state directly)
+    // Peer-based sync: the opponent sends their full live state. We use it ONLY
+    // to refresh our view of the enemy (gap repair / reconnect reconciliation).
+    //
+    // We deliberately do NOT reconstruct our OWN board from the opponent's
+    // `enemy*` mirror here: that mirror is the laggy copy and using it would
+    // overwrite our authoritative local state, causing the very desyncs we are
+    // trying to fix. Own-state recovery after a reload/reconnect is handled
+    // authoritatively by the server snapshot via `receive_stored_state`.
     socket.on("receive_full_state", (message) => {
       console.log("[receive_full_state] peer state received");
       const fullState = message.data || message;
       unstable_batchedUpdates(() => {
         applyEnemyState(dispatch, fullState);
-        // Recover own state from opponent's enemy* fields
-        dispatch(
-          restoreOwnState({
-            field: fullState.enemyField,
-            evoField: fullState.enemyEvoField,
-            hand: fullState.enemyHand,
-            playerHealth: fullState.enemyHealth,
-            playPoints: fullState.enemyPlayPoints,
-            evoPoints: fullState.enemyEvoPoints,
-            leader: fullState.enemyLeader,
-            leaderActive: fullState.enemyLeaderActive,
-            superEvoActive: fullState.enemySuperEvoActive,
-            cardback: fullState.enemyCardback,
-            cemetery: fullState.enemyCemetery,
-            banish: fullState.enemyBanish,
-            evoDeck: fullState.enemyEvoDeck,
-            engagedField: fullState.enemyEngagedField,
-            counterField: fullState.enemyCounterField,
-            auraField: fullState.enemyAuraField,
-            baneField: fullState.enemyBaneField,
-            wardField: fullState.enemyWardField,
-            customValues: fullState.enemyCustomValues,
-          }),
-        );
       });
     });
 

--- a/src/components/ui/PlayerUI.js
+++ b/src/components/ui/PlayerUI.js
@@ -26,6 +26,9 @@ import { motion } from "framer-motion";
 
 import { styled } from "@mui/material/styles";
 import Rating from "@mui/material/Rating";
+import WifiOffIcon from "@mui/icons-material/WifiOff";
+import WifiIcon from "@mui/icons-material/Wifi";
+import "../../css/EnemyUI.css";
 import FiberManualRecordIcon from "@mui/icons-material/FiberManualRecord";
 import FiberManualRecordOutlinedIcon from "@mui/icons-material/FiberManualRecordOutlined";
 import sepOn from "../../assets/logo/sep_on.png";
@@ -58,6 +61,9 @@ export default function PlayerUI({ name }) {
   const reduxShowDice = useSelector((state) => state.card.showDice);
   const reduxLeaderActive = useSelector((state) => state.card.leaderActive);
   const reduxRoom = useSelector((state) => state.card.room);
+  const reduxSelfOnlineStatus = useSelector(
+    (state) => state.card.selfOnlineStatus,
+  );
 
   useEffect(() => {
     dispatch(setHealth(playerHealth));
@@ -240,6 +246,17 @@ export default function PlayerUI({ name }) {
         )}
       </div>
       <Leader name={name} active={reduxLeaderActive} />
+
+      {reduxSelfOnlineStatus ? (
+        <div className={"onlineStatus"} title={"Connected"}>
+          <WifiIcon sx={{ height: 40, width: 40 }} />
+        </div>
+      ) : (
+        <div className={"offlineStatus"} title={"Disconnected — reconnecting…"}>
+          <WifiOffIcon sx={{ height: 40, width: 40 }} />
+        </div>
+      )}
+
       <div style={{ opacity: 0.75 }}>
         <img height={70} width={70} src={getClassFromLeader(name)} alt={name} />
       </div>

--- a/src/components/ui/Selection.js
+++ b/src/components/ui/Selection.js
@@ -53,7 +53,7 @@ import { cardImage } from "../../decks/getCards";
 
 import useMediaQuery from "@mui/material/useMediaQuery";
 import { useTheme } from "@mui/material/styles";
-import { socket } from "../../sockets";
+import { socket, clearSavedRoom } from "../../sockets";
 
 import {
   Box,
@@ -145,6 +145,7 @@ export default function Selection({ setSelectedOption }) {
 
   const exitToHome = () => {
     dispatch(exitGame());
+    clearSavedRoom();
     socket.emit("leave_room", reduxRoom.toString());
     navigate("/");
   };

--- a/src/pages/Home.js
+++ b/src/pages/Home.js
@@ -26,7 +26,7 @@ import {
 } from "../redux/CardSlice";
 import { deleteDeck } from "../redux/DeckSlice";
 import { cardImage } from "../decks/getCards";
-import { socket } from "../sockets";
+import { socket, saveRoom } from "../sockets";
 
 import ArrowBackIosNew from "@mui/icons-material/ArrowBackIosNew";
 import ArrowForwardIosIcon from "@mui/icons-material/ArrowForwardIos";
@@ -119,6 +119,7 @@ export default function Home() {
         const roomNumber = parseInt(Math.random() * 10000000);
         setRoomNumber(roomNumber.toString());
         dispatch(setRoom(roomNumber.toString()));
+        saveRoom(roomNumber.toString());
         socket.emit("create_room", roomNumber.toString());
       }
     }
@@ -128,6 +129,7 @@ export default function Home() {
       if (roomNumber !== "") {
         setRoomNumber(roomNumber.toString());
         dispatch(setRoom(roomNumber.toString()));
+        saveRoom(roomNumber.toString());
         socket.emit("join_room", roomNumber.toString());
       }
     }

--- a/src/redux/CardSlice.js
+++ b/src/redux/CardSlice.js
@@ -57,6 +57,7 @@ export const CardSlice = createSlice({
     currentEvo: "",
     room: "",
     enemyOnlineStatus: true,
+    selfOnlineStatus: true,
     activeUsers: 0,
     gameLog: [],
     chatLog: [],
@@ -427,6 +428,9 @@ export const CardSlice = createSlice({
     setEnemyOnlineStatus: (state, action) => {
       state.enemyOnlineStatus = action.payload;
       console.log("Enemy online status:", action.payload);
+    },
+    setSelfOnlineStatus: (state, action) => {
+      state.selfOnlineStatus = action.payload;
     },
     setLastChatMessage: (state, action) => {
       state.lastChatMessage = action.payload;
@@ -2838,6 +2842,7 @@ export const {
   setEnemyLog,
   setChat,
   setEnemyOnlineStatus,
+  setSelfOnlineStatus,
   setLastChatMessage,
   setEnemyChat,
   setViewingCardsLog,

--- a/src/sockets.js
+++ b/src/sockets.js
@@ -7,10 +7,27 @@ export const socket = io("https://shadowverse-server.onrender.com/", {
   transports: ["websocket"],
 });
 
-if (!sessionStorage.getItem("playerId")) {
-  sessionStorage.setItem("playerId", crypto.randomUUID());
+// Persist the player identity in localStorage so it survives a tab close /
+// reopen (sessionStorage only survives a reload of the same tab). The server
+// keys each player's stored board state by this id, so keeping it stable is
+// what lets a returning player recover their own state. Migrate any id that was
+// previously kept in sessionStorage so existing players aren't reset.
+let storedPlayerId = localStorage.getItem("playerId");
+if (!storedPlayerId) {
+  storedPlayerId = sessionStorage.getItem("playerId") || crypto.randomUUID();
+  localStorage.setItem("playerId", storedPlayerId);
 }
-export const playerId = sessionStorage.getItem("playerId");
+export const playerId = storedPlayerId;
+
+// Remember the current room across reloads so a hard refresh reconnects to the
+// same game instead of bouncing the player back to the home screen.
+const ROOM_KEY = "sve_room";
+export const saveRoom = (room) => {
+  if (room) localStorage.setItem(ROOM_KEY, room);
+  else localStorage.removeItem(ROOM_KEY);
+};
+export const getSavedRoom = () => localStorage.getItem(ROOM_KEY);
+export const clearSavedRoom = () => localStorage.removeItem(ROOM_KEY);
 
 socket.on("connect_error", (err) => {
   // the reason of the error, for example "xhr poll error"


### PR DESCRIPTION
## What & why

Fixes recurring board **desyncs**, makes a **page reload reconnect** to the active game, and adds a **self-disconnect indicator**.

## Desync handling

- Replace the dead in-order message queue with **per-sender gap detection** keyed on the server's new `_seq`/`_from` tags. Apply the newest value (last-write-wins) and, on a gap / sequence reset / new opponent id, request a throttled (≤1/1.5s) full-state resync via the existing `request_state` → `receive_full_state` path.
- `receive_full_state` now **only refreshes the enemy view**. It no longer reconstructs our own board from the opponent's laggy `enemy*` mirror — that was itself a desync / own-board-corruption source. Own-state recovery comes authoritatively from the server snapshot via `receive_stored_state`.

## Reconnect on reload

The `card` slice isn't persisted, so a hard reload previously bounced the player to Home.

- Persist `playerId` in `localStorage` (survives a tab close, not just a reload) so the server can still match our stored board.
- Remember the current room in `localStorage` on create/join; clear it on an intentional exit. On reload, `Field` restores the saved room and rejoins (`rejoin_room` + `request_stored_state`) instead of navigating home.

## Disconnect indicator

- Track this client's own connection (`selfOnlineStatus`) from the socket `connect`/`disconnect` events and show the `WifiOff` icon in `PlayerUI` while offline/reconnecting, mirroring the existing enemy indicator.

> ⚠️ Coupled with the matching `shadowverse-server` PR (gap detection reads `_seq`/`_from`). Merge/deploy together or server-first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
